### PR TITLE
fix freemix score percentage

### DIFF
--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -49,10 +49,12 @@ def annotate_workbook(sample_row, reports_path):
             )
         coverage_string = f"{coverage}%"
 
+       # The  freeMix score is % contamination predicted (where 0.1=10%).
+        # using * 100 to convert to percentage
         contamination = round(
-            sample_row[
+            (sample_row[
                 "VerifyBAMID_mqc-generalstats-verifybamid-FREEMIX"
-                ], 3
+                ]) * 100, 3
             )
         contamination_string = f"{contamination}%"
 

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -54,7 +54,7 @@ def annotate_workbook(sample_row, reports_path):
         contamination = round(
             (sample_row[
                 "VerifyBAMID_mqc-generalstats-verifybamid-FREEMIX"
-                ]) * 100, 3
+                ] * 100), 3
             )
         contamination_string = f"{contamination}%"
 


### PR DESCRIPTION
convert freemix score into percentage correctly rather than just copying value

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc_to_workbooks/4)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a clarifying comment explaining the calculation of the contamination metric from the freeMix score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->