### PR TITLE
Updated names of extracted QC metrics

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_multiqc_to_workbooks",
   "summary": "A tool to identify multiqc files and add data to reports workbooks",
   "dxapi": "1.0.0",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "changeLog": [
     {
         "version": "1.0.0",
@@ -14,7 +14,12 @@
       "version": "1.0.1",
       "date": "2025-07-21",
       "description": "Fix title, fix path to expected file for compatibility with uranus"
-  }
+    },
+    {
+      "version": "1.0.2",
+      "date": "2026-02-05",
+      "description": "Fix column names for updated MultiQC outputs"
+    }
 ],
   "inputSpec": [
     {

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -49,32 +49,34 @@ def annotate_workbook(sample_row, reports_path):
     try:
         coverage = round(
             sample_row[
-                "custom_coverage_mqc-generalstats-custom_coverage-250x"
+                "custom_content_custom_coverage-250x"
                 ], 1
             )
         coverage_string = f"{coverage}%"
 
-       # The  freeMix score is % contamination predicted (where 0.1=10%).
-        # using * 100 to convert to percentage
+       # The freeMix score is % contamination predicted
+       # conversion to percentage is now calculated during multiqc
         contamination = round(
             (sample_row[
-                "VerifyBAMID_mqc-generalstats-verifybamid-FREEMIX"
-                ] * 100), 3
+                "verifybamid-FREEMIX"
+                ]), 3
             )
         contamination_string = f"{contamination}%"
 
+        # number of mapped_passed reads is now divided by 1M during multiqc
         total_reads_M = round(
             (sample_row[
-                "Samtools_mqc-generalstats-samtools-mapped_passed"
-                ] / 1000000), 1
+                "samtools_flagstat-mapped_passed"
+                ]), 1
             )
 
         fold80 = round(sample_row["FOLD_80_BASE_PENALTY"],1)
 
         insert_size = int(sample_row[
-            "Picard_mqc-generalstats-picard-summed_median"
+            "picard_insertsizemetrics-summed_median"
             ])
         insert_size_string = f"{insert_size} bp"
+
         try:
             # if doenst exist try sex check format
             sex_check = sample_row["matched"]


### PR DESCRIPTION
The names of the extracted QC metrics have changed following a MultiQC update.

The arithmetic manipulations of `VerifyBAMID_mqc-generalstats-verifybamid-FREEMIX` and `Samtools_mqc-generalstats-samtools-mapped_passed` is now performed within MultiQC, so has been removed from this app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc_to_workbooks/11)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed column name mappings to support updated MultiQC output formats. Quality control metrics including coverage, contamination, read counts, and insert size are now correctly extracted from the latest MultiQC data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->