### PR TITLE
DI-3506 eggd_qc_to_workbooks

### DIFF
--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -94,9 +94,8 @@ def annotate_workbook(sample_row, reports_path):
     path = reports_path / (sample + ".xlsx")
     try:
         sample_workbook = openpyxl.load_workbook(path)
-    except FileNotFoundError:
-        logging.warning(f"No workbook found for {sample}")
-        return
+    except FileNotFoundError as err:
+        raise FileNotFoundError(f"No workbook found for {sample}") from err
 
     worksheet = sample_workbook['summary']
 
@@ -342,7 +341,7 @@ def main():
 
     logging.info("Beginning python")
     qc_table = create_combined_qc(multiqc_path)
-    logging.info(qc_table)
+    logging.info(len(qc_table), len(qc_table.columns))
 
     with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
         logging.info(f"Using {os.cpu_count()} CPU cores")

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -287,21 +287,74 @@ def annotate_gene_depths(intersect_path, file_suffix):
             f.result()
 
 
-print("Beginning python")
-qc_table = create_combined_qc(multiqc_path)
-print(qc_table)
+def main():
+    global config_file, file_suffix, intersect_suffix
+    args = parse_args()
 
-with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
-    print(f"Using {os.cpu_count()} CPU cores")
-    futures = [
-        executor.submit(annotate_workbook, row, reports_path)
-        for _, row in qc_table.iterrows()
-    ]
-    for f in futures:
-        f.result()
+    multiqc_folder = args.multiqc_folder
+    reports_folder = args.reports_folder
+    intersect_folder = args.intersect_folder
+    config = args.config
+    file_suffix = args.file_suffix
+    intersect_suffix = args.intersect_suffix
+
+    # read config string into dict
+    with open(config, "r") as f:
+        config_file = json.load(f)
+
+    logging.info(f"Config: {config_file}")
+
+    # validate config
+    cell_locations = config_file.get("cell_locations", {})
+    multiqc_file_names = config_file.get("multiqc_file_names", {})
+
+    required_cells = {
+        "250_coverage", "freemix", "M_reads", "fold_80",
+        "insert_size", "somalier", "somalier_text", "gene_depths"
+    }
+    required_multiqc_files = {
+        "general_stats_file", "hsmetrics_file",
+        "sexcheck_file", "somalier_file"
+    }
+
+    missing_cell_locations = [
+        f"cell_locations.{key}" for key in required_cells
+        if not cell_locations.get(key)]
+    missing_file_names = [
+        f"multiqc_file_names.{key}" for key in required_multiqc_files
+        if not multiqc_file_names.get(key)]
+    if missing_cell_locations or missing_file_names:
+        raise ValueError(f"Missing required config values: {', '.join(
+            missing_cell_locations + missing_file_names)}")
+
+    # set paths
+    multiqc_path = Path("multiqc_inputs") / multiqc_folder
+    reports_path = Path("reports_inputs") / reports_folder
+    intersect_path = Path("intersected_beds") / intersect_folder
+
+    logging.info(f"MultiQC path: {multiqc_path}")
+    logging.info(f"Reports path: {reports_path}")
+    logging.info(f"Intersected beds path: {intersect_path}")
+
+    logging.info("Beginning python")
+    qc_table = create_combined_qc(multiqc_path)
+    logging.info(qc_table)
+
+    with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
+        logging.info(f"Using {os.cpu_count()} CPU cores")
+        futures = [
+            executor.submit(annotate_workbook, row, reports_path)
+            for _, row in qc_table.iterrows()
+        ]
+        for f in futures:
+            f.result()
 
     logging.info("Reports annotated with run QC")
 
-annotate_gene_depths(intersect_path, file_suffix)
+    annotate_gene_depths(intersect_path, file_suffix)
 
-print("Reports annotated with gene depths")
+    logging.info("Reports annotated with gene depths")
+
+
+if __name__ == "__main__":
+    main()

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -2,77 +2,33 @@ import pandas as pd
 import openpyxl
 import argparse
 import json
-import sys
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor
 import os
+import logging
 
-# get paths from bash commandline arguments
-# improvement - use argparse
-parser = argparse.ArgumentParser(
-    description="Annotate sample workbooks with QC metrics")
-parser.add_argument("--multiqc_folder",
-                    help="Name of the MultiQC folder under multiqc_inputs/")
-parser.add_argument("--reports_folder",
-                    help="Name of the reports folder under reports_inputs/")
-parser.add_argument("--intersect_folder",
-                    help="Intersect folder name under intersected_beds/")
-parser.add_argument("--config",
-                    help="Path to config file with cell names and locations")
-parser.add_argument("--file_suffix",
-                    help="string for customisable file suffix")
-parser.add_argument("--intersect_suffix", default=".intersect.bed",
-                    help="suffix used to find intersected bed files")
-args = parser.parse_args()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(process)d] %(levelname)s: %(message)s"
+)
 
-multiqc_folder = args.multiqc_folder
-reports_folder = args.reports_folder
-intersect_folder = args.intersect_folder
-config = args.config
-file_suffix = args.file_suffix
-intersect_suffix = args.intersect_suffix
 
-# read config string into dict
-with open(config, "r") as f:
-    config_file = json.load(f)
-
-print(config_file)
-
-cell_locations = config_file.get("cell_locations", {})
-multiqc_file_names = config_file.get("multiqc_file_names", {})
-required_cells = {
-    "250_coverage",
-    "freemix",
-    "M_reads",
-    "fold_80",
-    "insert_size",
-    "somalier",
-    "somalier_text",
-    "gene_depths"}
-required_multiqc_files = {
-    "general_stats_file",
-    "hsmetrics_file",
-    "sexcheck_file",
-    "somalier_file"}
-
-missing_cell_locations = [
-    f"cell_locations.{key}" for key in required_cells
-    if not cell_locations.get(key)]
-missing_file_names = [
-    f"multiqc_file_names.{key}" for key in required_multiqc_files
-    if not multiqc_file_names.get(key)]
-if missing_cell_locations or missing_file_names:
-    missing = ', '.join(missing_cell_locations + missing_file_names)
-    raise ValueError(f"Missing required config values: {missing}")
-
-# set paths
-multiqc_path = Path("multiqc_inputs") / multiqc_folder
-reports_path = Path("reports_inputs") / reports_folder
-intersect_path = Path("intersected_beds") / intersect_folder
-
-print(multiqc_path)
-print(reports_path)
-print(intersect_path)
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Annotate sample workbooks with QC metrics")
+    parser.add_argument("--multiqc_folder",
+                        help="Name of MultiQC folder under multiqc_inputs/")
+    parser.add_argument("--reports_folder",
+                        help="Name of reports folder under reports_inputs/")
+    parser.add_argument("--intersect_folder",
+                        help="Intersect folder name under intersected_beds/")
+    parser.add_argument("--config",
+                        help="Path to config file with cell name and location")
+    parser.add_argument("--file_suffix",
+                        help="string for customisable file suffix")
+    parser.add_argument("--intersect_suffix", default=".intersect.bed",
+                        help="suffix used to find intersected bed files")
+    return parser.parse_args()
 
 
 def annotate_workbook(sample_row, reports_path):
@@ -123,24 +79,23 @@ def annotate_workbook(sample_row, reports_path):
             sex_check = sample_row["matched"]
             sex_check_string = f"{sex_check}"
         except KeyError as err:
-            print(f"Sex check value not found {err}, looking for somalier")
+            logging.info(f"No sex check value {err}, looking for somalier")
             try:
                 sex_check = sample_row["Match_Sexes"]
                 sex_check_string = f"Somalier used. Sex match: {sex_check}"
             except KeyError as err:
-                print(f"[WARN] {err}: Column missing for {sample}; skipping")
+                logging.warning(f"{err}: Column missing for {sample}; skipped")
                 return
     except KeyError as err:
-        print(f"[WARN] {err}: Column missing for {sample}; skipping")
+        logging.warning(f"{err}: Column missing for {sample}; skipped")
         return
 
     # get workbook corresponding to sample
-    print(sample)
     path = reports_path / (sample + ".xlsx")
     try:
         sample_workbook = openpyxl.load_workbook(path)
     except FileNotFoundError:
-        print("No workbook found for ", sample)
+        logging.warning("No workbook found for ", sample)
         return
 
     worksheet = sample_workbook['summary']
@@ -184,22 +139,22 @@ def create_combined_qc(multiqc_path):
     try:
         sexcheck = pd.read_csv(sexcheck_path, sep="\t")
     except FileNotFoundError as e:
-        print(f"sexcheck not found: {e.filename}, looking for somalier")
+        logging.info(f"Sexcheck not found: {e.filename}, looking for somalier")
         try:
             # if sex check file does not exist, find somalier check
             sexcheck = pd.read_csv(somalier_path, sep="\t")
         except FileNotFoundError as e:
-            sys.exit(f"[ERROR] Required MultiQC file missing: {e.filename}")
+            logging.error(f"Required MultiQC file missing: {e.filename}")
     except pd.errors.ParserError as e:
-        sys.exit(f"[ERROR] Failed to parse MultiQC file: {e}")
+        logging.error(f"Failed to parse MultiQC file: {e}")
 
     try:
         general_stats = pd.read_csv(general_stats_path, sep="\t")
         hsmetrics = pd.read_csv(hsmetrics_path, sep="\t")
     except FileNotFoundError as e:
-        sys.exit(f"[ERROR] Required MultiQC file missing: {e.filename}")
+        logging.error(f"Required MultiQC file missing: {e.filename}")
     except pd.errors.ParserError as e:
-        sys.exit(f"[ERROR] Failed to parse MultiQC file: {e}")
+        logging.error(f"Failed to parse MultiQC file: {e}")
 
     # combine into one qc table
     hs_sexcheck = pd.merge(hsmetrics, sexcheck, on="Sample")
@@ -253,7 +208,7 @@ def write_gene_depth_to_cell(worksheet, gene, depth, pos):
     gene_cells = config_file.get("cell_locations", {}).get(
         "gene_depths", {}).get(gene)
     if gene_cells is None:
-        print(f"[WARN] No cell locations configured for {gene}; skipping")
+        logging.warning(f"No cell locations configured for {gene}; skipped")
         return None, None
 
     worksheet[gene_cells["depth_text"]] = f"{gene}"
@@ -274,13 +229,12 @@ def process_workbooks(intersect_file, file_suffix, intersect_suffix):
     sample = intersect_file.name.replace(intersect_suffix, "")
     workbook_path = Path(sample + file_suffix)
     if not workbook_path.exists():
-        print(f"[WARN] No annotated workbook found at {workbook_path}")
-        # continue
+        logging.warning(f"No annotated workbook found at {workbook_path}")
         return
 
     gene_depths, gene_pos = get_min_depth_per_gene(intersect_file)
     if not gene_depths:
-        print(f"[WARN] No genes found for {intersect_file.name}")
+        logging.warning(f"No genes found for {intersect_file.name}")
 
     try:
         sample_workbook = openpyxl.load_workbook(workbook_path)
@@ -294,7 +248,7 @@ def process_workbooks(intersect_file, file_suffix, intersect_suffix):
                 depth=depth,
                 pos=pos)
             if depth_result is None:
-                print(f"[WARN] Skipped {gene}: no cell location")
+                logging.warning(f"Skipped {gene}: no cell location")
         sample_workbook.save(workbook_path)
     except (OSError, KeyError, ValueError) as e:
         raise RuntimeError(
@@ -344,7 +298,7 @@ with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
     for f in futures:
         f.result()
 
-print("Reports annotated with run QC")
+    logging.info("Reports annotated with run QC")
 
 annotate_gene_depths(intersect_path, file_suffix)
 

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -26,8 +26,7 @@ def parse_args():
                         help="Path to config file with cell name and location")
     parser.add_argument("--file_suffix", required=True,
                         help="string for customisable file suffix")
-    parser.add_argument("--intersect_suffix", required=True,
-                        default=".intersect.bed",
+    parser.add_argument("--intersect_suffix", default=".intersect.bed",
                         help="suffix used to find intersected bed files")
     return parser.parse_args()
 

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -95,7 +95,7 @@ def annotate_workbook(sample_row, reports_path):
     try:
         sample_workbook = openpyxl.load_workbook(path)
     except FileNotFoundError:
-        logging.warning("No workbook found for ", sample)
+        logging.warning(f"No workbook found for {sample}")
         return
 
     worksheet = sample_workbook['summary']
@@ -107,7 +107,7 @@ def annotate_workbook(sample_row, reports_path):
     worksheet[cell_locations["250_coverage"]] = coverage_string
     worksheet[cell_locations["freemix"]] = contamination_string
     worksheet[cell_locations["M_reads"]] = total_reads_M_string
-    worksheet[cell_locations["fold80"]] = fold80_string
+    worksheet[cell_locations["fold_80"]] = fold80_string
     worksheet[cell_locations["insert_size"]] = insert_size_string
     worksheet[cell_locations["somalier"]] = sex_check_string
 
@@ -145,16 +145,20 @@ def create_combined_qc(multiqc_path):
             sexcheck = pd.read_csv(somalier_path, sep="\t")
         except FileNotFoundError as e:
             logging.error(f"Required MultiQC file missing: {e.filename}")
+            raise
     except pd.errors.ParserError as e:
         logging.error(f"Failed to parse MultiQC file: {e}")
+        raise
 
     try:
         general_stats = pd.read_csv(general_stats_path, sep="\t")
         hsmetrics = pd.read_csv(hsmetrics_path, sep="\t")
     except FileNotFoundError as e:
         logging.error(f"Required MultiQC file missing: {e.filename}")
+        raise
     except pd.errors.ParserError as e:
         logging.error(f"Failed to parse MultiQC file: {e}")
+        raise
 
     # combine into one qc table
     hs_sexcheck = pd.merge(hsmetrics, sexcheck, on="Sample")
@@ -324,8 +328,8 @@ def main():
         f"multiqc_file_names.{key}" for key in required_multiqc_files
         if not multiqc_file_names.get(key)]
     if missing_cell_locations or missing_file_names:
-        raise ValueError(f"Missing required config values: {', '.join(
-            missing_cell_locations + missing_file_names)}")
+        missing = ', '.join(missing_cell_locations + missing_file_names)
+        raise ValueError(f"Missing required config values: {missing}")
 
     # set paths
     multiqc_path = Path("multiqc_inputs") / multiqc_folder

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -16,17 +16,18 @@ logging.basicConfig(
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Annotate sample workbooks with QC metrics")
-    parser.add_argument("--multiqc_folder",
+    parser.add_argument("--multiqc_folder", required=True,
                         help="Name of MultiQC folder under multiqc_inputs/")
-    parser.add_argument("--reports_folder",
+    parser.add_argument("--reports_folder", required=True,
                         help="Name of reports folder under reports_inputs/")
-    parser.add_argument("--intersect_folder",
+    parser.add_argument("--intersect_folder", required=True,
                         help="Intersect folder name under intersected_beds/")
-    parser.add_argument("--config",
+    parser.add_argument("--config", required=True,
                         help="Path to config file with cell name and location")
-    parser.add_argument("--file_suffix",
+    parser.add_argument("--file_suffix", required=True,
                         help="string for customisable file suffix")
-    parser.add_argument("--intersect_suffix", default=".intersect.bed",
+    parser.add_argument("--intersect_suffix", required=True,
+                        default=".intersect.bed",
                         help="suffix used to find intersected bed files")
     return parser.parse_args()
 

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -145,25 +145,16 @@ def annotate_workbook(sample_row, reports_path):
 
     worksheet = sample_workbook['summary']
 
-    # add "Somalier" to cell where header is currently added
+    # lookup cell locations and add data to sheet
+    cell_locations = config_file.get("cell_locations", {})
 
-    worksheet[config_file.get(
-        "cell_locations", {}).get("somalier_text")] = "Sex Check"
-
-    # add data to sheet
-    # want to pass cell locations in via a config for customisation
-    worksheet[config_file.get(
-        "cell_locations", {}).get("250_coverage")] = coverage_string
-    worksheet[config_file.get(
-        "cell_locations", {}).get("freemix")] = contamination_string
-    worksheet[config_file.get(
-        "cell_locations", {}).get("M_reads")] = total_reads_M_string
-    worksheet[config_file.get(
-        "cell_locations", {}).get("fold_80")] = fold80_string
-    worksheet[config_file.get(
-        "cell_locations", {}).get("insert_size")] = insert_size_string
-    worksheet[config_file.get(
-        "cell_locations", {}).get("somalier")] = sex_check_string
+    worksheet[cell_locations["somalier_text"]] = "Sex Check"
+    worksheet[cell_locations["250_coverage"]] = coverage_string
+    worksheet[cell_locations["freemix"]] = contamination_string
+    worksheet[cell_locations["M_reads"]] = total_reads_M_string
+    worksheet[cell_locations["fold80"]] = fold80_string
+    worksheet[cell_locations["insert_size"]] = insert_size_string
+    worksheet[cell_locations["somalier"]] = sex_check_string
 
     # save file
     new_path = sample + file_suffix

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -181,6 +181,8 @@ def get_min_depth_per_gene(intersect_path):
             fields = line.strip().split("\t")
             if len(fields) < 8:
                 continue
+            # this assumes output from bedtools intersect run with
+            # -wa -wb mosdepth per base bed + target bed
             depth = int(fields[3])
             gene = fields[7]
             pos = fields[5]

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -17,8 +17,8 @@ parser.add_argument("--reports_folder",
                     help="Name of the reports folder under reports_inputs/")
 parser.add_argument("--intersect_folder",
                     help="Intersect folder name under intersected_beds/")
-parser.add_argument("--config_json",
-                    help="JSON string mapping metric names to cell addresses")
+parser.add_argument("--config",
+                    help="Path to config file with cell names and locations")
 parser.add_argument("--file_suffix",
                     help="string for customisable file suffix")
 parser.add_argument("--intersect_suffix", default=".intersect.bed",
@@ -28,12 +28,13 @@ args = parser.parse_args()
 multiqc_folder = args.multiqc_folder
 reports_folder = args.reports_folder
 intersect_folder = args.intersect_folder
-config_json = args.config_json
+config = args.config
 file_suffix = args.file_suffix
 intersect_suffix = args.intersect_suffix
 
 # read config string into dict
-config_file = json.loads(config_json)
+with open(config, "r") as f:
+    config_file = json.load(f)
 
 print(config_file)
 

--- a/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
+++ b/resources/home/dnanexus/annotate_workbooks/annotate_workbooks_with_QC.py
@@ -341,7 +341,6 @@ def main():
 
     logging.info("Beginning python")
     qc_table = create_combined_qc(multiqc_path)
-    logging.info(len(qc_table), len(qc_table.columns))
 
     with ProcessPoolExecutor(max_workers=os.cpu_count()) as executor:
         logging.info(f"Using {os.cpu_count()} CPU cores")

--- a/src/eggd_qc_to_workbooks.sh
+++ b/src/eggd_qc_to_workbooks.sh
@@ -19,15 +19,10 @@ set -exo pipefail
 
 main() {
 
-<<<<<<< HEAD
-    echo "Value of path_to_multiqc_folder: '$path_to_multiqc_folder'"
-    echo "Value of path_to_reports_folder: '$path_to_reports_folder'"
-=======
     echo "path_to_multiqc_folder: '$path_to_multiqc_folder'"
     echo "path_to_reports_folder: '$path_to_reports_folder'"
     echo "path_to_mosdepth_folder: '$path_to_mosdepth_folder'"
     echo "path_to_bedfile: '$path_to_bedfile'"
->>>>>>> 9f49931 (Accept config file path as argument)
     dx-download-all-inputs --parallel
     # Fill in your application code here.
     #

--- a/src/eggd_qc_to_workbooks.sh
+++ b/src/eggd_qc_to_workbooks.sh
@@ -90,12 +90,13 @@ main() {
     while IFS= read -r -d '' bed; do
         sample=$(basename "$bed" _markdup.per-base.bed.gz)
         out_bed="/home/dnanexus/intersected_beds/${sample}.intersect.bed"
-        bedtools intersect -a "$bed" -b "/home/dnanexus/bedfile/bedfile.bed" -wa -wb > "$out_bed"
+        bedtools intersect -a "$bed" -b "/home/dnanexus/bedfile/bedfile.bed" -wa -wb > "$out_bed" &
         echo "Processed $sample -> $out_bed"
 
         job_count=$((job_count + 1))
         if (( job_count >= max_jobs )); then
             wait
+            job_count=0
         fi
     done < <(find /home/dnanexus/mosdepth_inputs -name "*_markdup.per-base.bed.gz" -print0)
 

--- a/src/eggd_qc_to_workbooks.sh
+++ b/src/eggd_qc_to_workbooks.sh
@@ -70,15 +70,15 @@ main() {
     cd /home/dnanexus/
 
     mkdir /home/dnanexus/mosdepth_inputs
-	cd /home/dnanexus/mosdepth_inputs
+    cd /home/dnanexus/mosdepth_inputs
     dx find data --path "$path_to_mosdepth_folder" --name "*_markdup.per-base.bed.gz" --brief > /tmp/mosdepth_ids.txt
     cat /tmp/mosdepth_ids.txt | xargs -P 8 -n 1 dx download
-	cd /home/dnanexus/
+    cd /home/dnanexus/
     
-	mkdir /home/dnanexus/bedfile
-	cd /home/dnanexus/bedfile
-	dx download "$path_to_bedfile" -o bedfile.bed
-	cd /home/dnanexus
+    mkdir /home/dnanexus/bedfile
+    cd /home/dnanexus/bedfile
+    dx download "$path_to_bedfile" -o bedfile.bed
+    cd /home/dnanexus
 
     echo "running bedtools"
 	intersect_folder="/home/dnanexus/intersected_beds"

--- a/src/eggd_qc_to_workbooks.sh
+++ b/src/eggd_qc_to_workbooks.sh
@@ -69,8 +69,9 @@ main() {
 
     mkdir /home/dnanexus/mosdepth_inputs
     cd /home/dnanexus/mosdepth_inputs
-    dx find data --path "$path_to_mosdepth_folder" --name "*_markdup.per-base.bed.gz" --brief > /tmp/mosdepth_ids.txt
-    cat /tmp/mosdepth_ids.txt | xargs -P 8 -n 1 dx download
+    mosdepth_ids="$(mktmp)"
+    dx find data --path "$path_to_mosdepth_folder" --name "*_markdup.per-base.bed.gz" --brief > "$mosdepth_ids"
+    xargs -r -P 8 -n 1 dx download < "$mosdepth_ids"
     cd /home/dnanexus/
     
     mkdir /home/dnanexus/bedfile

--- a/src/eggd_qc_to_workbooks.sh
+++ b/src/eggd_qc_to_workbooks.sh
@@ -19,8 +19,15 @@ set -exo pipefail
 
 main() {
 
+<<<<<<< HEAD
     echo "Value of path_to_multiqc_folder: '$path_to_multiqc_folder'"
     echo "Value of path_to_reports_folder: '$path_to_reports_folder'"
+=======
+    echo "path_to_multiqc_folder: '$path_to_multiqc_folder'"
+    echo "path_to_reports_folder: '$path_to_reports_folder'"
+    echo "path_to_mosdepth_folder: '$path_to_mosdepth_folder'"
+    echo "path_to_bedfile: '$path_to_bedfile'"
+>>>>>>> 9f49931 (Accept config file path as argument)
     dx-download-all-inputs --parallel
     # Fill in your application code here.
     #
@@ -38,8 +45,6 @@ main() {
     # exit code will prematurely exit the script; if no error was
     # reported in the job_error.json file, then the failure reason
     # will be AppInternalError with a generic error message.
-    cells_to_edit=$(jq -r '.' "$config_file_path" )
-    #echo "$cells_to_edit"
 
     echo "environment setup"
 
@@ -61,9 +66,7 @@ main() {
     dx download -r "$path_to_multiqc_folder"
     cd /home/dnanexus/
 
-    # echo $(basename "$path_to_reports_folder")
     reports_folder=$(basename "$path_to_reports_folder")
-
     mkdir /home/dnanexus/reports_inputs
     cd /home/dnanexus/reports_inputs
     dx download -r "$path_to_reports_folder"
@@ -106,7 +109,7 @@ main() {
 
     python3 annotate_workbooks/annotate_workbooks_with_QC.py --multiqc_folder "$multiqc_folder" \
     --reports_folder "$reports_folder" --intersect_folder "$intersect_folder" \
-    --config_json "$cells_to_edit" --file_suffix "$file_suffix"
+    --config "$config_file_path" --file_suffix "$file_suffix"
     # The following line(s) use the utility dx-jobutil-add-output to format and
     # add output variables to your job's output as appropriate for the output
     # class.  Run "dx-jobutil-add-output -h" for more information on what it

--- a/src/eggd_qc_to_workbooks.sh
+++ b/src/eggd_qc_to_workbooks.sh
@@ -69,9 +69,8 @@ main() {
 
     mkdir /home/dnanexus/mosdepth_inputs
     cd /home/dnanexus/mosdepth_inputs
-    mosdepth_ids="$(mktmp)"
-    dx find data --path "$path_to_mosdepth_folder" --name "*_markdup.per-base.bed.gz" --brief > "$mosdepth_ids"
-    xargs -r -P 8 -n 1 dx download < "$mosdepth_ids"
+    dx find data --path "$path_to_mosdepth_folder" --name "*_markdup.per-base.bed.gz" --brief > /tmp/mosdepth_ids.txt
+    cat /tmp/mosdepth_ids.txt | xargs -P 8 -n 1 dx download
     cd /home/dnanexus/
     
     mkdir /home/dnanexus/bedfile


### PR DESCRIPTION
annotate_workbooks_with_QC.py
- Refactor execution logic
- Add logging

eggd_qc_to_workbooks.sh

- Accept config file as input

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc_to_workbooks/14)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined workbook QC annotation into a command-line workflow with a clear entry point.
  * Switched from inline JSON input to a config file path for easier setup and use.
  * Standardised logging and error handling for missing QC data and workbook inputs.

* **Bug Fixes**
  * Improved fallback behaviour when sex-check data is unavailable.
  * Added earlier exits when required QC columns, gene data, or annotated workbooks are missing.
  * Tightened validation so missing configuration keys are surfaced more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->